### PR TITLE
Store ingested filesnames, to skip in the next run

### DIFF
--- a/api/predictive_parking/get_os_data.py
+++ b/api/predictive_parking/get_os_data.py
@@ -5,17 +5,17 @@ We use the objectstore to get the latest and greatest of the mks dump
 import re
 import isoweek
 import os
+import json
 import logging
 from pathlib import Path
 
 from swiftclient.client import Connection
+from swiftclient.exceptions import ClientException
 
 from dateutil import parser
 
 logging.basicConfig(level=logging.DEBUG)
 log = logging.getLogger(__file__)
-
-assert os.getenv('PARKEERVAKKEN_OBJECTSTORE_PASSWORD')
 
 DATE_RE = re.compile('\d\d\d\d\d\d')
 YEAR_RE = re.compile('\d\d\d\d')
@@ -101,7 +101,7 @@ def full_file_list():
     return rars_sorted_by_time
 
 
-def should_we_download_this(rarname: str, start_month: int, end_month: int) -> bool:
+def should_we_download_this(rarname: str, start_month: int, end_month: int, handled_files: set) -> bool:
     """
     Check if we should download this rar files
 
@@ -125,22 +125,26 @@ def should_we_download_this(rarname: str, start_month: int, end_month: int) -> b
             file_month = int(m[0])
 
     if not file_month:
-        log.debug('date not parsed from file name')
+        log.debug('date not parsed from file name: %s', rarname)
         return False
 
     if start_month:
         if file_month < start_month:
-            log.debug('skiped %s, too old', rarname)
+            log.debug('skipped %s, too old', rarname)
             return False
     if end_month:
         if file_month >= end_month:
-            log.debug('skiped %s, too new', rarname)
+            log.debug('skipped %s, too new', rarname)
             return False
+
+    if rarname in handled_files:
+        log.debug('skipped %s file previously added', rarname)
+        return False
 
     return True
 
 
-def get_latest_rarfiles():
+def get_latest_rarfiles(storage):
     """
     Get latest rarfile
     """
@@ -156,6 +160,8 @@ def get_latest_rarfiles():
     if os.getenv('ENDDATE'):
         # 201708
         end_month = int(os.getenv('ENDDATE'))
+
+    handled_files = storage.load_handled_files()
 
     log.debug('STARTDATE: %s', start_month)
     log.debug('ENDDATE: %s', end_month)
@@ -173,13 +179,13 @@ def get_latest_rarfiles():
             rar_files.append((time, object_meta_data))
 
         # given selection pick rar files.
-        if should_we_download_this(rarname, start_month, end_month):
+        if should_we_download_this(rarname, start_month, end_month, handled_files):
             rar_files.append((time, object_meta_data))
 
     return rar_files
 
 
-def download_files(rar_files):
+def download_files(rar_files, storage):
 
     for time, object_meta_data in rar_files:
 
@@ -200,8 +206,77 @@ def download_files(rar_files):
         with open('{}/{}'.format(DATA_DIR, rarname), 'wb') as outputzip:
             outputzip.write(latest_zip)
 
+    #TODO discuss if there is better place, moment within the ETL process
+    #Files are stored but not yet processed added in the database.
+    cleaned_names = (parse_name(i['name']) for _, i in rar_files)
+    storage.save_handled_files(cleaned_names)
+
+
+def parse_name(full_name):
+    return full_name.split('/')[-1]
+
+
+class StoreObjectStorage:
+    def __init__(self, filename='handled_files', connection=None, container_name=None):
+        self.filename = filename
+        self.container_name = container_name
+        self.connection = connection
+        self.whitelisted = [
+            'datapunt_import_status/test',
+            'datapunt_import_status/acceptance',
+            'datapunt_import_status/production',
+        ]
+
+        assert self.container_name is not None
+
+    def load(self, container_name=None, filename=None):
+        try:
+            return self.connection.get_object(container_name or self.container_name, filename or self.filename)
+        except ClientException:
+            raise
+
+    def save(self, data, container_name=None, filename=None):
+        self.connection.put_object(container_name or self.container_name, filename or self.filename, data)
+
+    def save_handled_files(self, file_names, filename=None):
+        """To save the new set of files, combined them with previous seen files."""
+        assert self.container_name in self.whitelisted
+
+        prev_files = self.load_handled_files(filename=filename, suppress=True)
+        combined_files = prev_files.union(set(file_names))
+        json_files = json.dumps({'files': list(combined_files)})
+        try:
+            self.save(json_files, self.container_name, filename or self.filename)
+        except ClientException:
+            log.warning("Failed to save file")
+
+    def load_handled_files(self, filename=None, suppress=False):
+        assert self.container_name in self.whitelisted
+
+        try:
+            item = self.load(self.container_name, filename or self.filename)
+            return set(json.loads(item[1].decode('utf-8'))['files'])
+        except ClientException:
+            if not suppress:
+                log.warning('Exception during connection with object storage, previously handled files are not skipped')
+            return set()
+        except (json.decoder.JSONDecodeError, ValueError):
+            log.warning(
+                'Exception parsing obj storage response, previously handled files are not skipped')
+            return set()
+
 
 if __name__ == '__main__':
     # get_parkeerkans_db_dumps()
-    rar_files_to_download = get_latest_rarfiles()
-    download_files(rar_files_to_download)
+    assert os.getenv('PARKEERVAKKEN_OBJECTSTORE_PASSWORD')
+    if os.getenv('HANDLED_FILES_ENV') is None:
+        log.warning("HANDLED_FILES_ENV not set, previous loaded files are not skipped")
+
+    storage = StoreObjectStorage(
+        filename='handled_files',
+        container_name= os.getenv('HANDLED_FILES_ENV') or 'datapunt_import_status/test',
+        connection=parkeren_conn
+    )
+    rar_files_to_download = get_latest_rarfiles(storage)
+    download_files(rar_files_to_download, storage)
+

--- a/api/predictive_parking/get_os_data_test.py
+++ b/api/predictive_parking/get_os_data_test.py
@@ -1,0 +1,159 @@
+import os
+import unittest
+from unittest.mock import patch
+from collections import defaultdict
+
+from swiftclient.client import Connection
+from swiftclient.exceptions import ClientException
+
+from get_os_data import parkeren_conn, StoreObjectStorage
+
+
+valid_json_result = ({}, b'{"files": ["bar", "etc", "foo"]}')
+invalid_json_result = ({}, b'{"files": ["bar", "etc", "foo",]}')
+
+
+class TestHandledFiles(unittest.TestCase):
+
+    def tearDown(self):
+
+        # ensure environment variables are removed
+        environment_vars_used = [
+            'HANDLED_FILES_ENV_TEST',
+            'datapunt_import_status/HANDLED_FILES_ENV_TEST'
+        ]
+        for item in environment_vars_used:
+            if item in os.environ:
+                del os.environ[item]
+
+    @patch.object(Connection, 'get_object', return_value=valid_json_result)
+    def test_load_handled_files_valid_json(self, _):
+        store = StoreObjectStorage('handled_files_test', container_name='foobar', connection=Connection())
+        store.whitelisted.append('foobar')
+
+        items = store.load_handled_files()
+        self.assertEqual(items, {'foo', 'bar', 'etc'})
+
+    @patch.object(Connection, 'get_object', return_value=invalid_json_result)
+    def test_load_handled_files_invalid(self, _):
+        store = StoreObjectStorage('handled_files_test', container_name='foobar', connection=Connection())
+        store.whitelisted.append('foobar')
+
+        items = store.load_handled_files()
+        self.assertEqual(items, set())
+
+    def test_load_handled_files_no_connection(self):
+        store = StoreObjectStorage(
+            filename='handled_files',
+            container_name='foobar',
+            connection=MockedConnection(unable_to_connect=True)
+        )
+        store.whitelisted.append('foobar')
+
+        file_names = ['foo', 'bar', 'etc']
+
+        # How to handle load and save during connection errors, do we fail and continue
+        store.save_handled_files(file_names)
+        store.whitelisted.append('foobar')
+
+        # items should be empty since there is no internet connection
+        items = store.load_handled_files()
+        self.assertEqual(items, set())
+
+    def test_save_handled_files(self):
+        store = StoreObjectStorage(
+            filename='handled_files_test',
+            container_name='foobar',
+            connection=MockedConnection()
+        )
+        store.whitelisted.append('foobar')
+
+        file_names = ['foo', 'bar', 'etc']
+
+        store.save_handled_files(file_names)
+        store.whitelisted.append('foobar')
+        items = store.load_handled_files()
+        self.assertEqual(items, {'foo', 'bar', 'etc'})
+
+    def test_save_handled_files_overwrite(self):
+        store = StoreObjectStorage(
+            filename='handled_files_test',
+            container_name='foobar',
+            connection=MockedConnection()
+        )
+        store.whitelisted.append('foobar')
+
+        file_names = ['foo', 'bar', 'etc']
+
+        items = store.load_handled_files()
+        self.assertEqual(items, set([]))
+
+        store.save_handled_files(file_names)
+        items = store.load_handled_files()
+
+        self.assertEqual(items, {'foo', 'bar', 'etc'})
+
+        items = store.load_handled_files(filename="foo")
+        self.assertEqual(items, set([]))
+
+        store.save_handled_files(file_names, filename="foo")
+        items = store.load_handled_files(filename="foo")
+        self.assertEqual(items, {'foo', 'bar', 'etc'})
+
+        file_names = ['etc', 'def']
+        store.save_handled_files(file_names, filename="foo")
+        items = store.load_handled_files(filename="foo")
+        self.assertEqual(items, {'foo', 'bar', 'etc', 'def'})
+
+    @unittest.skip
+    def test_save_load_overwrite_to_prod_object_store(self):
+        """Warning this test will connect with the production object store"""
+        store = StoreObjectStorage(filename='handled_files_test', container_name='datapunt_import_status/test', connection=parkeren_conn)
+
+        file_names = ['foo', 'bar', 'etc']
+
+        store.save_handled_files(file_names)
+
+        items = store.load_handled_files()
+        self.assertEqual(items, {'foo', 'bar', 'etc'})
+
+        file_names = ['def']
+        store.save_handled_files(file_names)
+
+        items = store.load_handled_files()
+        self.assertEqual(items, {'foo', 'bar', 'etc', 'def'})
+
+        # empty the file after the test
+        store.save('')
+        items = store.load_handled_files()
+        self.assertEqual(items, set())
+
+
+class MockedConnection:
+    def __init__(self, unable_to_find_file=False, unable_to_connect=False):
+        self.store = defaultdict(dict)
+        self.unable_to_find_file = unable_to_find_file
+        self.unable_to_connect = unable_to_connect
+
+    def get_object(self, container_name, filename):
+        if self.unable_to_connect:
+            raise ClientException("Mocked unable to connect")
+        try:
+            return self.store[container_name][filename]
+        except KeyError:
+            raise ClientException('Mocked')
+
+    def put_object(self, container_name, filename, data):
+        if self.unable_to_connect:
+            raise ClientException("Mocked unable to connect")
+
+        if self.unable_to_find_file:
+            raise ClientException("Mocked resource could not be found")
+
+        self.store[container_name].setdefault(filename, {})
+        self.store[container_name][filename] = ({}, bytes(data, 'utf-8'))
+
+
+if __name__ == '__main__':
+    unittest.main()
+


### PR DESCRIPTION
FIXES #OP-565

Added storing of filenames in the objectstore. Subsequent ingestion
runs can skip files that are already ingested.